### PR TITLE
fix binding to multicast socket fails in ios close #6

### DIFF
--- a/lib/src/ssdp/ssdp_controller.dart
+++ b/lib/src/ssdp/ssdp_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 typedef NetworkInterfacesFactory = Future<Iterable<NetworkInterface>> Function(
     InternetAddressType type);
@@ -82,7 +83,10 @@ class SSDPController {
 
       _incoming.multicastLoopback = false;
       _incoming.multicastHops = 12;
-      _incoming.joinMulticast(_address, interface);
+      final value = Uint8List.fromList(
+          _address.rawAddress + interface.addresses[0].rawAddress);
+      _incoming
+          .setRawOption(RawSocketOption(RawSocketOption.levelIPv4, 12, value));
     }
     _incoming.listen(_handleIncoming);
     _started = true;


### PR DESCRIPTION
看sdk的issues，应该是sdk的问题，具体解决方法是按照[https://github.com/dart-lang/sdk/issues/42250](https://github.com/dart-lang/sdk/issues/42250#issuecomment-759026385) 这里给的规避方案

在 [ios14.6 / iPhone8 / 荣耀盒子(乐播投屏)] 的环境下测试通过